### PR TITLE
Recursively compare the branches of a node in nodes-equalp.

### DIFF
--- a/btrie.lisp
+++ b/btrie.lisp
@@ -153,7 +153,7 @@
   (and
    (equal (key a) (key b))
    (equal (width a) (width b))
-   (equal (branches a) (branches b))))
+   (every #'nodes-equalp (branches a) (branches b))))
 
 
 ;;; Retrieval

--- a/tests.lisp
+++ b/tests.lisp
@@ -35,11 +35,11 @@
 
 (lift:addtest (test-nodes-equalp)
   leaf-nodes
-  (ensure-same (make-leaf) (make-leaf)))
+  (ensure-same (make-leaf) (make-leaf) :test #'nodes-equalp))
 
 (lift:addtest (test-nodes-equalp)
   empty-tries
-  (ensure-same (make-trie) (make-trie)))
+  (ensure-same (make-trie) (make-trie) :test #'nodes-equalp))
 
 
 ;;; Retrieval
@@ -53,9 +53,7 @@
 (lift:addtest (test-obtain-seq)
   simple-lookup
   (let ((tr (make-trie *banana*)))
-    (with-slots ((k key) (w width) (b branches))
-        (let ((result-node ))
-          (ensure-same 
-           (obtain-seq tr "banana")
-           (make-node :key #\a :width 1 :branches (list (make-leaf)))
-           :test #'nodes-equalp)))))
+    (ensure-same 
+     (obtain-seq tr "banana")
+     (make-node :key #\a :width 1 :branches (list (make-leaf)))
+     :test #'nodes-equalp)))


### PR DESCRIPTION
This was causing some of the lift tests to fail.
## Before

```
BTRIE-TESTS> (run-tests :suite 'btrie-tests)
Start: BTRIE-TESTS
Start: BTRIE-LOOKUP
Start: TEST-OBTAIN-SEQ
Start: BTRIE-PREDICATES
Start: TEST-NODES-EQUALP
Start: TEST-INIT
#<Results for BTRIE-TESTS 4 Tests, 3 Failures>

BTRIE-TESTS> (describe *)
Test Report for BTRIE-TESTS: 4 tests run, 3 Failures.

Failure: test-obtain-seq : simple-lookup

  Condition    : Ensure-same: (a 1 .) is not NODES-EQUALP to (a 1 .)
  During       : END-TEST
  Code         : 
  ((LET ((TR (MAKE-TRIE *BANANA*)))
     (WITH-SLOTS ((K KEY) (W WIDTH) (B BRANCHES))
         (LET ((RESULT-NODE))
           (ENSURE-SAME (OBTAIN-SEQ TR "banana")
                        (MAKE-NODE :KEY #\a :WIDTH 1 :BRANCHES
                                   (LIST (MAKE-LEAF)))
                        :TEST #'NODES-EQUALP)))))

Failure: test-nodes-equalp : leaf-nodes

  Condition    : Ensure-same: (. 1 is not equal to (. 1
  During       : END-TEST
  Code         : 
  ((ENSURE-SAME #1=(MAKE-LEAF) #1#))

Failure: test-nodes-equalp : empty-tries

  Condition    : Ensure-same: ("" 0 is not equal to ("" 0
  During       : END-TEST
  Code         : 
  ((ENSURE-SAME #1=(MAKE-TRIE) #1#))

Test Report for BTRIE-TESTS: 4 tests run, 3 Failures.
; No value
```
## After

```
BTRIE-TESTS> (run-tests :suite 'btrie-tests)
Start: BTRIE-TESTS
Start: BTRIE-LOOKUP
Start: TEST-OBTAIN-SEQ
Start: BTRIE-PREDICATES
Start: TEST-NODES-EQUALP
Start: TEST-INIT
#<Results for BTRIE-TESTS [4 Successful tests]>
```
