### PR TITLE
Fixes for print-words and nodes-equalp

### DIFF
--- a/btrie.lisp
+++ b/btrie.lisp
@@ -325,7 +325,7 @@
     (let ((width (width trie)))
       ;; Print the word and it's count, if the count is not 0 or 1.
       ;; Logand makes 1 or 0 => 0 to suppress printing.
-      (format t "~A~:[~;~10t~d~]~%" prefix (/= 0 (logand -2 width)) width))
+      (format stream "~A~:[~;~10t~d~]~%" prefix (/= 0 (logand -2 width)) width))
     (return-from print-words))
 
   (loop as branch in (branches trie) do

--- a/btrie.lisp
+++ b/btrie.lisp
@@ -153,7 +153,7 @@
   (and
    (equal (key a) (key b))
    (equal (width a) (width b))
-   (equal (branches a) (branches b))))
+   (every #'nodes-equalp (branches a) (branches b))))
 
 
 ;;; Retrieval

--- a/tests.lisp
+++ b/tests.lisp
@@ -57,3 +57,23 @@
      (obtain-seq tr "banana")
      (make-node :key #\a :width 1 :branches (list (make-leaf)))
      :test #'nodes-equalp)))
+
+
+;;; Printing
+
+(lift:deftestsuite btrie-traversal-and-printing (btrie-tests)
+  ())
+
+(lift:deftestsuite test-print-words (btrie-traversal-and-printing)
+  ())
+
+(lift:addtest (test-print-words)
+  print-to-stream
+  (let ((tr (make-trie *banana*)))
+    (ensure-same
+     (with-output-to-string (std-out-stream)
+       (let ((*standard-output* std-out-stream))
+	 (print-words tr)))
+     (with-output-to-string (user-supplied-stream)
+       (print-words tr user-supplied-stream))
+     :test #'string=)))

--- a/tests.lisp
+++ b/tests.lisp
@@ -35,11 +35,11 @@
 
 (lift:addtest (test-nodes-equalp)
   leaf-nodes
-  (ensure-same (make-leaf) (make-leaf)))
+  (ensure-same (make-leaf) (make-leaf) :test #'nodes-equalp))
 
 (lift:addtest (test-nodes-equalp)
   empty-tries
-  (ensure-same (make-trie) (make-trie)))
+  (ensure-same (make-trie) (make-trie) :test #'nodes-equalp))
 
 
 ;;; Retrieval
@@ -53,9 +53,7 @@
 (lift:addtest (test-obtain-seq)
   simple-lookup
   (let ((tr (make-trie *banana*)))
-    (with-slots ((k key) (w width) (b branches))
-        (let ((result-node ))
-          (ensure-same 
-           (obtain-seq tr "banana")
-           (make-node :key #\a :width 1 :branches (list (make-leaf)))
-           :test #'nodes-equalp)))))
+    (ensure-same 
+     (obtain-seq tr "banana")
+     (make-node :key #\a :width 1 :branches (list (make-leaf)))
+     :test #'nodes-equalp)))


### PR DESCRIPTION
Respect the optional STREAM argument in `print-words`, rather than always printing to `*standard-ouput*`.

Also, recursively check that a node's branches are equal in `nodes-equalp`, and fix a couple of failing unit tests.

Please ignore the previous pull request, as this pull request contains that commit as well.
## Before nodes-equalp fixes

```
BTRIE-TESTS> (run-tests :suite 'btrie-tests)
Start: BTRIE-TESTS
Start: BTRIE-LOOKUP
Start: TEST-OBTAIN-SEQ
Start: BTRIE-PREDICATES
Start: TEST-NODES-EQUALP
Start: TEST-INIT
#<Results for BTRIE-TESTS 4 Tests, 3 Failures>

BTRIE-TESTS> (describe *)
Test Report for BTRIE-TESTS: 4 tests run, 3 Failures.

Failure: test-obtain-seq : simple-lookup

Condition    : Ensure-same: (a 1 .) is not NODES-EQUALP to (a 1 .)
During       : END-TEST
Code         : 
((LET ((TR (MAKE-TRIE *BANANA*)))
(WITH-SLOTS ((K KEY) (W WIDTH) (B BRANCHES))
(LET ((RESULT-NODE))
(ENSURE-SAME (OBTAIN-SEQ TR "banana")
(MAKE-NODE :KEY #\a :WIDTH 1 :BRANCHES
(LIST (MAKE-LEAF)))
:TEST #'NODES-EQUALP)))))

Failure: test-nodes-equalp : leaf-nodes

Condition    : Ensure-same: (. 1 is not equal to (. 1
During       : END-TEST
Code         : 
((ENSURE-SAME #1=(MAKE-LEAF) #1#))

Failure: test-nodes-equalp : empty-tries

Condition    : Ensure-same: ("" 0 is not equal to ("" 0
During       : END-TEST
Code         : 
((ENSURE-SAME #1=(MAKE-TRIE) #1#))

Test Report for BTRIE-TESTS: 4 tests run, 3 Failures.
; No value
```
## After nodes-equalp fixes

```
BTRIE-TESTS> (run-tests :suite 'btrie-tests)
Start: BTRIE-TESTS
Start: BTRIE-LOOKUP
Start: TEST-OBTAIN-SEQ
Start: BTRIE-PREDICATES
Start: TEST-NODES-EQUALP
Start: TEST-INIT
#<Results for BTRIE-TESTS [4 Successful tests]>
```
## Before print-words fix

```
BTRIE-TESTS> (run-tests)

Start: TEST-PRINT-WORDSc
as
an
ar
are
b
barn
bar
bare
ban
bane
banana
#<Results for TEST-PRINT-WORDS 1 Test, 1 Failure>

BTRIE-TESTS> (describe *)
Test Report for TEST-PRINT-WORDS: 1 test run, 1 Failure.

Failure: test-print-words : print-to-stream

Condition    : Ensure-same: "c
as
an
ar
are
b
barn
bar
bare
ban
bane
banana
" is not STRING= to ""
During       : END-TEST
Code         : 
((LET ((TR (MAKE-TRIE *BANANA*)))
(ENSURE-SAME
(WITH-OUTPUT-TO-STRING (STD-OUT-STREAM)
(LET ((*STANDARD-OUTPUT* STD-OUT-STREAM))
(PRINT-WORDS TR)))
(WITH-OUTPUT-TO-STRING (USER-SUPPLIED-STREAM)
(PRINT-WORDS TR USER-SUPPLIED-STREAM))
:TEST #'STRING=)))

Test Report for TEST-PRINT-WORDS: 1 test run, 1 Failure.
; No value
```
## After print-words fix

```
BTRIE-TESTS> (run-tests :suite 'btrie-tests)
Start: BTRIE-TESTS
Start: BTRIE-TRAVERSAL-AND-PRINTING
Start: TEST-PRINT-WORDS
Start: BTRIE-LOOKUP
Start: TEST-OBTAIN-SEQ
Start: BTRIE-PREDICATES
Start: TEST-NODES-EQUALP
Start: TEST-INIT
#<Results for BTRIE-TESTS [5 Successful tests]>
```
