### PR TITLE
Follow ASDF3 guideline of a single primary system per .asd file

### DIFF
--- a/btrie.asd
+++ b/btrie.asd
@@ -1,22 +1,22 @@
-(in-package #:cl-user)
-(defpackage #:nu.composed.btrie.system
-  (:use #:cl #:asdf))
-(in-package #:nu.composed.btrie.system)
 
 (defsystem btrie
   :author "Peter Hillerström <peter.hillerstrom@gmail.com>"
   :license "Simplified BSD license."
   :version "0.2.1"
-  :description "Branch trie - a generic trie implementation with branch widths.
+  :description "Generic trie implementation with branch widths"
+  :long-description "Branch trie - a generic trie implementation with branch widths.
 
 * Implementation is generic: keys can be of sequences of any type.
 * Branch width of a trie node tells how many branches go through that node and
   can be used to calculate probabilites for different suffixes."
   :depends-on (:arnesi :split-sequence :lift)
   :serial t
-  :components ((:file "btrie")))
+  :components ((:file "btrie"))
+  :in-order-to ((test-op (test-op :btrie/tests))))
 
-(defsystem btrie-tests
+(defsystem btrie/tests
   :depends-on (:btrie :lift :metabang-bind)
   :serial t
-  :components ((:file "tests")))
+  :components ((:file "tests"))
+  :perform (test-op (o c) 
+             (symbol-call :lift :describe (symbol-call :lift :run-tests :suite :btrie-tests))))


### PR DESCRIPTION
ASDF3 recommends declaring a single primary system per `.asd` file (e.g., `FOO`), with other, optional subsystems being named with a slash (e.g., `FOO/BAR`). This ensures that `FOO/BAR` can be loaded without first having to manually load `FOO`, as would be the case with e.g. `FOO-BAR` (ASDF would look for it in a non-existent `foo-bar.asd`).

See: [info asdf find-system](https://asdf.common-lisp.dev/asdf.html#Components-1)
